### PR TITLE
Rank top repos by commits + stars with recency weighting

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -69,15 +69,7 @@ func (collector *Collector) Collect(ctx context.Context, cfg internalconfig.Conf
 		effectiveLanguage = mergeLanguageStats(weightedOwned, externalEstimatedLanguage)
 	}
 
-	sort.Slice(activities, func(left int, right int) bool {
-		if activities[left].Activity == activities[right].Activity {
-			return activities[left].RepositoryName < activities[right].RepositoryName
-		}
-		return activities[left].Activity > activities[right].Activity
-	})
-	if len(activities) > 6 {
-		activities = activities[:6]
-	}
+	topRepos := collector.rankTopRepos(cfg, ownedRepositories, activities)
 
 	sort.Slice(externalEstimates, func(left int, right int) bool {
 		if externalEstimates[left].WeightedEstimatedBytes == externalEstimates[right].WeightedEstimatedBytes {
@@ -102,7 +94,7 @@ func (collector *Collector) Collect(ctx context.Context, cfg internalconfig.Conf
 			RepositoryCount:    len(ownedRepositories),
 		},
 		Languages: effectiveLanguage,
-		TopRepos:  activities,
+		TopRepos:  topRepos,
 		Diagnostics: internalmodel.DiagnosticsReport{
 			Scope:                     diagnosticsScope,
 			Summary:                   buildDiagnosticsSummary(cfg, len(ownedRepositories), len(externalRepositories), includedOwnedCount, weightedOwned, externalEstimates),
@@ -116,6 +108,40 @@ func (collector *Collector) Collect(ctx context.Context, cfg internalconfig.Conf
 		},
 		Repositories: ownedRepositories,
 	}, nil
+}
+
+const topRepoLimit = 6
+
+func (collector *Collector) rankTopRepos(cfg internalconfig.Config, ownedRepositories []internalmodel.Repository, activities []internalmodel.RepoActivity) []internalmodel.RepoActivity {
+	repositoryByName := make(map[string]internalmodel.Repository, len(ownedRepositories))
+	for _, repository := range ownedRepositories {
+		repositoryByName[repository.NameWithOwner] = repository
+	}
+
+	ranked := make([]internalmodel.RepoActivity, 0, len(activities))
+	for _, activity := range activities {
+		repository, found := repositoryByName[activity.RepositoryName]
+		if !found {
+			continue
+		}
+		if repositoryExclusionReason(cfg, repository, sumRepositoryBytes(repository)) != "" {
+			continue
+		}
+		activity.Stars = repository.Stars
+		activity.Score = (math.Log10(1+float64(activity.Commits)) + math.Log10(1+float64(activity.Stars))) * collector.recencyWeight(cfg, repository)
+		ranked = append(ranked, activity)
+	}
+
+	sort.Slice(ranked, func(left int, right int) bool {
+		if ranked[left].Score == ranked[right].Score {
+			return ranked[left].RepositoryName < ranked[right].RepositoryName
+		}
+		return ranked[left].Score > ranked[right].Score
+	})
+	if len(ranked) > topRepoLimit {
+		ranked = ranked[:topRepoLimit]
+	}
+	return ranked
 }
 
 func (collector *Collector) collectLanguages(cfg internalconfig.Config, repositories []internalmodel.Repository) ([]internalmodel.LanguageStat, []internalmodel.LanguageStat, []internalmodel.InclusionDecision, int) {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -235,11 +235,8 @@ func assertTopReposOrdering(t *testing.T, repos []internalmodel.RepoActivity) {
 
 	expected := []string{
 		"me/recent-go",
-		"me/shared-sdk",
 		"me/older-rust",
-		"me/forked-go",
-		"me/archived-old",
-		"me/excluded-repo",
+		"me/shared-sdk",
 	}
 	actual := make([]string, 0, len(repos))
 	for _, repository := range repos {
@@ -247,6 +244,20 @@ func assertTopReposOrdering(t *testing.T, repos []internalmodel.RepoActivity) {
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("unexpected top repo order: got %v want %v", actual, expected)
+	}
+
+	for _, repository := range repos {
+		if repository.Score <= 0 {
+			t.Fatalf("expected positive top-repo score for %q, got %.6f", repository.RepositoryName, repository.Score)
+		}
+	}
+	for index := 1; index < len(repos); index += 1 {
+		if repos[index-1].Score < repos[index].Score {
+			t.Fatalf("expected top repos sorted by score desc, got %.6f before %.6f", repos[index-1].Score, repos[index].Score)
+		}
+	}
+	if repos[0].RepositoryName != "me/recent-go" || repos[0].Commits != 50 || repos[0].Stars != 10 {
+		t.Fatalf("unexpected top repo commits/stars: %+v", repos[0])
 	}
 }
 

--- a/internal/collector/testdata/sdk_fixture.json
+++ b/internal/collector/testdata/sdk_fixture.json
@@ -187,31 +187,31 @@
   "activities": [
     {
       "repositoryName": "me/shared-sdk",
-      "activity": 100
+      "commits": 200
     },
     {
       "repositoryName": "me/recent-go",
-      "activity": 100
+      "commits": 50
     },
     {
       "repositoryName": "me/older-rust",
-      "activity": 90
+      "commits": 120
     },
     {
       "repositoryName": "me/forked-go",
-      "activity": 80
+      "commits": 90
     },
     {
       "repositoryName": "me/archived-old",
-      "activity": 70
+      "commits": 70
     },
     {
       "repositoryName": "me/excluded-repo",
-      "activity": 60
+      "commits": 60
     },
     {
       "repositoryName": "me/no-langs",
-      "activity": 50
+      "commits": 40
     }
   ],
   "additions": 111,

--- a/internal/githubapi/client_test.go
+++ b/internal/githubapi/client_test.go
@@ -145,15 +145,15 @@ func TestFetchRepositoryCommitActivityPaginates(t *testing.T) {
 		},
 	}
 
-	activity, additions, deletions, err := client.fetchRepositoryCommitActivity(context.Background(), query, "actor-id", "agoodkind", "stats-gh")
+	commits, additions, deletions, err := client.fetchRepositoryCommitActivity(context.Background(), query, "actor-id", "agoodkind", "stats-gh")
 	if err != nil {
 		t.Fatalf("fetchRepositoryCommitActivity returned error: %v", err)
 	}
 	if requests != 2 {
 		t.Fatalf("unexpected request count %d", requests)
 	}
-	if activity != 20 {
-		t.Fatalf("unexpected activity %d", activity)
+	if commits != 2 {
+		t.Fatalf("unexpected commit count %d", commits)
 	}
 	if additions != 12 {
 		t.Fatalf("unexpected additions %d", additions)

--- a/internal/githubapi/graphql.go
+++ b/internal/githubapi/graphql.go
@@ -225,18 +225,18 @@ func (client *Client) FetchContributorActivity(ctx context.Context, repositories
 			continue
 		}
 
-		activity, additions, deletions, err := client.fetchRepositoryCommitActivity(ctx, activityQuery, actorID, owner, repo)
+		commits, additions, deletions, err := client.fetchRepositoryCommitActivity(ctx, activityQuery, actorID, owner, repo)
 		if err != nil {
 			slog.ErrorContext(ctx, "skip repository commit activity", "repository", repository.NameWithOwner, "error", err)
 			continue
 		}
-		if activity <= 0 {
+		if commits <= 0 {
 			continue
 		}
 
 		activities = append(activities, internalmodel.RepoActivity{
 			RepositoryName: repository.NameWithOwner,
-			Activity:       activity,
+			Commits:        commits,
 		})
 		totalAdditions += additions
 		totalDeletions += deletions
@@ -266,7 +266,7 @@ func (client *Client) fetchActorID(ctx context.Context) (string, error) {
 }
 
 func (client *Client) fetchRepositoryCommitActivity(ctx context.Context, query string, actorID string, owner string, repo string) (int, int, int, error) {
-	activity := 0
+	commits := 0
 	additions := 0
 	deletions := 0
 	cursor := ""
@@ -291,13 +291,13 @@ func (client *Client) fetchRepositoryCommitActivity(ctx context.Context, query s
 			additions += commit.Additions
 			deletions += commit.Deletions
 		}
-		activity = additions + deletions
+		commits += len(history.Nodes)
 		if !history.PageInfo.HasNextPage {
 			break
 		}
 		cursor = history.PageInfo.EndCursor
 	}
-	return activity, additions, deletions, nil
+	return commits, additions, deletions, nil
 }
 
 func mapRepositories(nodes []repositoryNode, source internalmodel.RepositorySource) []internalmodel.Repository {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -54,8 +54,10 @@ type InclusionDecision struct {
 }
 
 type RepoActivity struct {
-	RepositoryName string `json:"repositoryName"`
-	Activity       int    `json:"activity"`
+	RepositoryName string  `json:"repositoryName"`
+	Commits        int     `json:"commits"`
+	Stars          int     `json:"stars"`
+	Score          float64 `json:"score"`
 }
 
 type ExternalContributionEstimate struct {

--- a/internal/render/svg.go
+++ b/internal/render/svg.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -24,6 +25,7 @@ const (
 	topReposTemplatePath     = "templates/top_repos.svg.tmpl"
 	fallbackColor            = "#586069"
 	topRepositoryNameDefault = "Top GitHub Repos"
+	topRepoMinBarPercent     = 25.0
 )
 
 var hexColorPattern = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
@@ -129,20 +131,25 @@ func buildLanguageTemplateData(languages []internalmodel.LanguageStat) languageT
 
 func buildTopReposTemplateData(name string, repos []internalmodel.RepoActivity) topReposTemplateData {
 	maxScore := 0.0
+	minScore := math.MaxFloat64
 	for _, repo := range repos {
 		if repo.Score > maxScore {
 			maxScore = repo.Score
 		}
+		if repo.Score < minScore {
+			minScore = repo.Score
+		}
 	}
+	scoreRange := maxScore - minScore
 	colors := []string{"#3572A5", "#555555", "#3178c6", "#DA3434", "#89e051", "#00ADD8"}
 	rows := make([]topRepoView, 0, len(repos))
 	for index, repo := range repos {
-		width := 0.0
-		if maxScore > 0 {
-			width = 100 * repo.Score / maxScore
+		width := 100.0
+		if scoreRange > 0 {
+			width = topRepoMinBarPercent + (repo.Score-minScore)/scoreRange*(100-topRepoMinBarPercent)
 		}
 		rows = append(rows, topRepoView{
-			RepositoryName:      strings.TrimSpace(repo.RepositoryName),
+			RepositoryName:      stripOwnerPrefix(strings.TrimSpace(repo.RepositoryName)),
 			Display:             fmt.Sprintf("%s · ★%s", formatInteger(repo.Commits), formatInteger(repo.Stars)),
 			Color:               sanitizeColor(colors[index%len(colors)]),
 			WidthDisplayPercent: fmt.Sprintf("%.2f", clampPercentage(width)),
@@ -154,6 +161,13 @@ func buildTopReposTemplateData(name string, repos []internalmodel.RepoActivity) 
 		displayName = topRepositoryNameDefault
 	}
 	return topReposTemplateData{Name: displayName, Repos: rows}
+}
+
+func stripOwnerPrefix(repositoryName string) string {
+	if index := strings.Index(repositoryName, "/"); index >= 0 {
+		return repositoryName[index+1:]
+	}
+	return repositoryName
 }
 
 func sanitizeColor(color string) string {

--- a/internal/render/svg.go
+++ b/internal/render/svg.go
@@ -51,7 +51,7 @@ type languageTemplateItem struct {
 
 type topRepoView struct {
 	RepositoryName      string
-	Activity            string
+	Display             string
 	Color               string
 	WidthDisplayPercent string
 }
@@ -128,22 +128,22 @@ func buildLanguageTemplateData(languages []internalmodel.LanguageStat) languageT
 }
 
 func buildTopReposTemplateData(name string, repos []internalmodel.RepoActivity) topReposTemplateData {
-	maxActivity := 0
+	maxScore := 0.0
 	for _, repo := range repos {
-		if repo.Activity > maxActivity {
-			maxActivity = repo.Activity
+		if repo.Score > maxScore {
+			maxScore = repo.Score
 		}
 	}
 	colors := []string{"#3572A5", "#555555", "#3178c6", "#DA3434", "#89e051", "#00ADD8"}
 	rows := make([]topRepoView, 0, len(repos))
 	for index, repo := range repos {
 		width := 0.0
-		if maxActivity > 0 {
-			width = 100 * float64(repo.Activity) / float64(maxActivity)
+		if maxScore > 0 {
+			width = 100 * repo.Score / maxScore
 		}
 		rows = append(rows, topRepoView{
 			RepositoryName:      strings.TrimSpace(repo.RepositoryName),
-			Activity:            formatInteger(repo.Activity),
+			Display:             fmt.Sprintf("%s · ★%s", formatInteger(repo.Commits), formatInteger(repo.Stars)),
 			Color:               sanitizeColor(colors[index%len(colors)]),
 			WidthDisplayPercent: fmt.Sprintf("%.2f", clampPercentage(width)),
 		})

--- a/internal/render/svg_test.go
+++ b/internal/render/svg_test.go
@@ -46,7 +46,9 @@ func TestWriteSVGsEscapesDangerousContent(t *testing.T) {
 		TopRepos: []internalmodel.RepoActivity{
 			{
 				RepositoryName: `repo <script>alert("repo")</script>`,
-				Activity:       42000,
+				Commits:        42000,
+				Stars:          7,
+				Score:          1.0,
 			},
 		},
 	}
@@ -69,8 +71,8 @@ func TestWriteSVGsEscapesDangerousContent(t *testing.T) {
 	if strings.Contains(topReposSVG, `A <script>alert("x")</script>`) {
 		t.Fatalf("expected top_repos.svg to escape owner names")
 	}
-	if !strings.Contains(topReposSVG, `42,000`) {
-		t.Fatalf("expected formatted activity in top_repos.svg, got %s", topReposSVG)
+	if !strings.Contains(topReposSVG, `42,000 · ★7`) {
+		t.Fatalf("expected formatted commits/stars in top_repos.svg, got %s", topReposSVG)
 	}
 
 	overviewSVGBytes, err := os.ReadFile(filepath.Join(generatedDirectory, "overview.svg"))

--- a/internal/render/svg_test.go
+++ b/internal/render/svg_test.go
@@ -45,7 +45,7 @@ func TestWriteSVGsEscapesDangerousContent(t *testing.T) {
 		},
 		TopRepos: []internalmodel.RepoActivity{
 			{
-				RepositoryName: `repo <script>alert("repo")</script>`,
+				RepositoryName: `owner/repo<script>alert("repo")</script>`,
 				Commits:        42000,
 				Stars:          7,
 				Score:          1.0,
@@ -65,8 +65,11 @@ func TestWriteSVGsEscapesDangerousContent(t *testing.T) {
 	if strings.Contains(topReposSVG, `<script>alert("repo")</script>`) {
 		t.Fatalf("expected top_repos.svg to escape repository names")
 	}
-	if !strings.Contains(topReposSVG, `repo &lt;script&gt;alert(&#34;repo&#34;)&lt;/script&gt;`) {
+	if !strings.Contains(topReposSVG, `repo&lt;script&gt;alert(&#34;repo&#34;)&lt;/script&gt;`) {
 		t.Fatalf("expected escaped repository name in top_repos.svg, got %s", topReposSVG)
+	}
+	if strings.Contains(topReposSVG, `owner/`) {
+		t.Fatalf("expected top_repos.svg to strip owner prefix from repository name, got %s", topReposSVG)
 	}
 	if strings.Contains(topReposSVG, `A <script>alert("x")</script>`) {
 		t.Fatalf("expected top_repos.svg to escape owner names")

--- a/internal/render/templates/languages.svg.tmpl
+++ b/internal/render/templates/languages.svg.tmpl
@@ -1,4 +1,4 @@
-<svg id="gh-dark-mode-only" width="360" height="210" xmlns="http://www.w3.org/2000/svg">
+<svg id="gh-dark-mode-only" width="360" height="380" xmlns="http://www.w3.org/2000/svg">
 <style>
 svg {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
@@ -125,7 +125,7 @@ div.ellipsis {
 <g>
 <rect x="5" y="5" id="background" />
 <g>
-<foreignObject x="21" y="17" width="318" height="176">
+<foreignObject x="21" y="17" width="318" height="346">
 <div xmlns="http://www.w3.org/1999/xhtml" class="ellipsis">
 
 <h2>Languages Used</h2>

--- a/internal/render/templates/languages.svg.tmpl
+++ b/internal/render/templates/languages.svg.tmpl
@@ -128,7 +128,7 @@ div.ellipsis {
 <foreignObject x="21" y="17" width="318" height="176">
 <div xmlns="http://www.w3.org/1999/xhtml" class="ellipsis">
 
-<h2>Languages Used (Weighted Owned Repositories)</h2>
+<h2>Languages Used</h2>
 
 <div>
 <span class="progress">

--- a/internal/render/templates/top_repos.svg.tmpl
+++ b/internal/render/templates/top_repos.svg.tmpl
@@ -98,7 +98,7 @@ tr {
 <rect fill="{{ $repo.Color }}" width="{{ $repo.WidthDisplayPercent }}%" height="100%"></rect>
 </svg>
 </td>
-<td width="20%"><div>{{ $repo.Activity }}</div></td>
+<td width="20%"><div>{{ $repo.Display }}</div></td>
 </tr>
 {{ end }}
 </tbody>


### PR DESCRIPTION
Replace the lines-changed signal (additions + deletions) with a composite
score combining commits-by-viewer, stargazers, and the same recency
half-life used for language stats:

    score = (log10(1 + commits) + log10(1 + stars)) * recencyWeight

Log scaling balances the two signals so neither popularity nor commit
volume drowns the other out, and the recency multiplier discounts
dormant repos. The top-repos pipeline also now applies the same
exclusion filters as the language pipeline (archived, disabled,
fork-when-ExcludeForks, excluded_repos, missing language data), so junk
no longer wins.

The SVG cell now shows "{commits} · ★{stars}" instead of a raw
lines-changed total, and the bar width is driven by the composite
score. The redundant "(Weighted Owned Repositories)" parenthetical is
removed from the languages SVG subtitle.