### PR TITLE
[codex] Update Go CI status grouping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  ci:
+  go:
     uses: agoodkind/go-makefile/.github/workflows/_ci.yml@main
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Renames the caller job for the shared go-makefile CI workflow from `ci` to `go`, so reusable-workflow checks render as `CI / go / <gate>` instead of `CI / ci / <gate>`.

## Validation

- Ran `actionlint` in this worktree.
- Ran `git diff --check` in this worktree.
- Verified the diff only changes the caller job key from `ci` to `go`.
