### PR TITLE
[codex] Allow stats CI OIDC permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,4 @@ jobs:
     uses: agoodkind/go-makefile/.github/workflows/_ci.yml@main
     permissions:
       contents: read
+      id-token: write


### PR DESCRIPTION
## Summary

- Allow the go-makefile reusable CI caller to pass id-token: write to the called workflow.

## Validation
- git diff --check
