### PR TITLE
Limit CI workflow triggers to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master]
   pull_request:
+    branches: [master]
 
 permissions:
   contents: read


### PR DESCRIPTION
### Summary

This change keeps the Go CI workflow on pull requests and default-branch pushes only.

PR branch pushes no longer start an extra `CI` run, so each PR update should show the pull request run without a duplicate push run.

## Change

The `push` trigger now targets the repo default branch, and the `pull_request` trigger is limited to the same branch.

The reusable `agoodkind/go-makefile` job and existing workflow jobs stay unchanged.

## Testing

- `git diff --check`
- `actionlint .github/workflows/ci.yml`
