### PR TITLE
Trigger CI on every branch push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+    branches: ['**']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Normalize the CI trigger so every branch push, including master, runs CI exactly once with no duplication.

## What changed
- `push.branches` is now `['**']`, so CI runs on every branch push (master included) on the push event only.
- Removed the `pull_request` trigger, which eliminates the duplicate run that previously fired on both push and pull_request for branches targeting master.
- Added `concurrency` keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, so a newer push on the same ref cancels the in-flight run.

## Why this is safe
- PRs still surface checks: the push run is associated with the head SHA, so GitHub shows the check on the PR.
- The `'**'` branch glob matches branches but not tags, so tag-driven release workflows are untouched.
- `name:`, top-level `permissions:`, and the entire `jobs:` section (the `go` job calling `agoodkind/go-makefile/.github/workflows/_ci.yml@main`) are preserved byte-for-byte.

Part of a fleet-wide CI trigger normalization.